### PR TITLE
refactor: introduce storage interface

### DIFF
--- a/backend/cli.ts
+++ b/backend/cli.ts
@@ -27,6 +27,7 @@ program
   .action(async (options) => {
     const startTime = Date.now();
     let webServer: WebServer | null = null;
+    let storage: Database | null = null;
 
     try {
       let planFile: string;
@@ -177,14 +178,14 @@ program
       }
 
       const eventEmitter = new OrchestratorEventEmitter();
-      const database = new Database(workDir);
+      storage = new Database(workDir);
 
       if (options.ui) {
         webServer = new WebServer({
           port: options.port,
           eventEmitter,
           autoOpen: options.autoOpen,
-          database
+          storage
         });
 
         await webServer.start();
@@ -198,7 +199,8 @@ program
         agentTimeoutMinutes: options.agentTimeout,
         eventEmitter,
         silent: options.ui,
-        executionId
+        executionId,
+        storage
       });
 
       eventEmitter.on('event', (event) => {
@@ -251,6 +253,8 @@ program
         console.log('═'.repeat(80));
 
         await new Promise(() => {});
+      } else if (storage) {
+        storage.close();
       }
 
       process.exit(0);
@@ -274,6 +278,10 @@ program
 
       if (webServer) {
         await webServer.stop();
+      }
+
+      if (storage) {
+        storage.close();
       }
 
       process.exit(1);

--- a/backend/database.ts
+++ b/backend/database.ts
@@ -2,8 +2,9 @@ import BetterSqlite3 from 'better-sqlite3';
 import * as path from 'path';
 import * as fs from 'fs';
 import { Plan, DbStep, Iteration, Issue } from './models';
+import { Storage, IterationUpdate } from './storage';
 
-export class Database {
+export class Database implements Storage {
   private db: BetterSqlite3.Database;
 
   constructor(workDir: string, databasePath?: string) {
@@ -160,7 +161,7 @@ export class Database {
     return stmt.all(stepId) as Iteration[];
   }
 
-  updateIteration(iterationId: number, updates: Partial<Omit<Iteration, 'id' | 'stepId' | 'iterationNumber' | 'type' | 'createdAt'>>): void {
+  updateIteration(iterationId: number, updates: IterationUpdate): void {
     const updatedAt = new Date().toISOString();
     const fields: string[] = [];
     const values: (string | number | null)[] = [];

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -5,4 +5,5 @@ export { CodexRunner, CodexRunOptions } from './codex-runner';
 export { GitHubChecker, GitHubConfig } from './github-checker';
 export { PROMPTS } from './prompts';
 export { Database } from './database';
+export { Storage, IterationUpdate } from './storage';
 export { Plan, DbStep, Iteration, Issue } from './models';

--- a/backend/storage.ts
+++ b/backend/storage.ts
@@ -1,0 +1,33 @@
+import { Plan, DbStep, Iteration, Issue } from './models';
+
+export type IterationUpdate = Partial<
+  Omit<Iteration, 'id' | 'stepId' | 'iterationNumber' | 'type' | 'createdAt'>
+>;
+
+export interface Storage {
+  createPlan(planFilePath: string, workDir: string, owner: string, repo: string): Plan;
+  getPlan(id: number): Plan | undefined;
+
+  createStep(planId: number, stepNumber: number, title: string): DbStep;
+  getSteps(planId: number): DbStep[];
+  updateStepStatus(stepId: number, status: DbStep['status']): void;
+
+  createIteration(stepId: number, iterationNumber: number, type: Iteration['type']): Iteration;
+  getIterations(stepId: number): Iteration[];
+  updateIteration(iterationId: number, updates: IterationUpdate): void;
+
+  createIssue(
+    iterationId: number,
+    type: Issue['type'],
+    description: string,
+    filePath?: string | null,
+    lineNumber?: number | null,
+    severity?: Issue['severity'],
+    status?: Issue['status'],
+  ): Issue;
+  getIssues(iterationId: number): Issue[];
+  updateIssueStatus(issueId: number, status: Issue['status'], resolvedAt?: string): void;
+  getOpenIssues(stepId: number): Issue[];
+
+  close(): void;
+}


### PR DESCRIPTION
## Summary
- add a storage interface and expose it alongside the existing SQLite implementation
- update the orchestrator, CLI, and web server to consume any storage implementation and share a single instance
- keep the SQLite-backed Database compliant with the new storage contract

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ea4d72c2bc8332894c697680323ba8