### PR TITLE
Fix Jest resolution for ESM modules

### DIFF
--- a/backend/claude-runner.ts
+++ b/backend/claude-runner.ts
@@ -4,8 +4,14 @@ import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { PROMPTS } from "./prompts.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const moduleDir = (() => {
+  try {
+    const url = new Function("return import.meta.url")() as string;
+    return dirname(fileURLToPath(url));
+  } catch {
+    return typeof __dirname !== "undefined" ? __dirname : process.cwd();
+  }
+})();
 
 export interface ClaudeRunOptions {
   workDir: string;
@@ -15,7 +21,7 @@ export interface ClaudeRunOptions {
 
 export class ClaudeRunner {
   private getClaudePath(): string {
-    const localBin = resolve(__dirname, "../node_modules/.bin/claude");
+    const localBin = resolve(moduleDir, "../node_modules/.bin/claude");
 
     console.log(`Looking for Claude Code binary at: ${localBin}`);
 

--- a/backend/codex-runner.ts
+++ b/backend/codex-runner.ts
@@ -3,8 +3,14 @@ import { existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const moduleDir = (() => {
+  try {
+    const url = new Function("return import.meta.url")() as string;
+    return dirname(fileURLToPath(url));
+  } catch {
+    return typeof __dirname !== "undefined" ? __dirname : process.cwd();
+  }
+})();
 
 export interface CodexRunOptions {
   workDir: string;
@@ -24,7 +30,7 @@ export interface CodexReviewResult {
 
 export class CodexRunner {
   private getCodexPath(): string {
-    const localBin = resolve(__dirname, "../node_modules/.bin/codex");
+    const localBin = resolve(moduleDir, "../node_modules/.bin/codex");
 
     console.log(`Looking for Codex binary at: ${localBin}`);
 

--- a/backend/ui/tui-adapter.ts
+++ b/backend/ui/tui-adapter.ts
@@ -6,8 +6,14 @@ import type * as ReactTypes from 'react';
 import { pathToFileURL, fileURLToPath } from 'url';
 import { resolve, dirname } from 'path';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const moduleDir = (() => {
+  try {
+    const url = new Function('return import.meta.url')() as string;
+    return dirname(fileURLToPath(url));
+  } catch {
+    return typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+  }
+})();
 
 type InkModule = typeof import('ink');
 type ReactModule = typeof import('react');
@@ -36,9 +42,9 @@ export class TUIAdapter implements UIAdapter {
     this.ink = await import('ink');
     this.React = await import('react');
 
-    const isDev = process.env.NODE_ENV !== 'production' && !__dirname.includes('/dist/');
+    const isDev = process.env.NODE_ENV !== 'production' && !moduleDir.includes('/dist/');
     const fileName = isDev ? 'App.tsx' : 'App.js';
-    const componentPath = resolve(__dirname, '../tui/components', fileName);
+    const componentPath = resolve(moduleDir, '../tui/components', fileName);
     const componentUrl = pathToFileURL(componentPath).href;
 
     const componentsModule = await import(componentUrl);

--- a/backend/ui/websocket-adapter.ts
+++ b/backend/ui/websocket-adapter.ts
@@ -10,8 +10,14 @@ import open from 'open';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const moduleDir = (() => {
+  try {
+    const url = new Function('return import.meta.url')() as string;
+    return dirname(fileURLToPath(url));
+  } catch {
+    return typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+  }
+})();
 
 export interface WebSocketUIAdapterConfig extends UIAdapterConfig {
   port?: number;
@@ -50,7 +56,7 @@ export class WebSocketUIAdapter implements UIAdapter {
   }
 
   private setupRoutes(): void {
-    const frontendDistPath = path.resolve(__dirname, '../../frontend/dist');
+    const frontendDistPath = path.resolve(moduleDir, '../../frontend/dist');
 
     this.app.use(express.static(frontendDistPath));
 

--- a/backend/web-server.ts
+++ b/backend/web-server.ts
@@ -8,8 +8,14 @@ import open from 'open';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const moduleDir = (() => {
+  try {
+    const url = new Function('return import.meta.url')() as string;
+    return dirname(fileURLToPath(url));
+  } catch {
+    return typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+  }
+})();
 
 export interface WebServerConfig {
   port?: number;
@@ -47,7 +53,7 @@ export class WebServer {
   }
 
   private setupRoutes(): void {
-    const frontendDistPath = path.resolve(__dirname, '../frontend/dist');
+    const frontendDistPath = path.resolve(moduleDir, '../frontend/dist');
 
     this.app.use(express.static(frontendDistPath));
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ export default {
     'backend/**/*.ts',
     '!backend/**/*.d.ts'
   ],
+  resolver: './jest.resolver.cjs',
   moduleNameMapper: {
     '^@octokit/(.*)$': '<rootDir>/backend/__mocks__/@octokit/$1.ts'
   }

--- a/jest.resolver.cjs
+++ b/jest.resolver.cjs
@@ -1,0 +1,12 @@
+module.exports = (request, options) => {
+  const defaultResolver = options.defaultResolver;
+  if (request.endsWith('.js')) {
+    const tsRequest = request.replace(/\.js$/, '.ts');
+    try {
+      return defaultResolver(tsRequest, options);
+    } catch (err) {
+      // ignore and fall back to default resolution
+    }
+  }
+  return defaultResolver(request, options);
+};


### PR DESCRIPTION
## Summary
- add a custom Jest resolver so relative .js imports resolve to the TypeScript sources
- update backend runners and UI adapters to derive module directories without relying on import.meta, keeping CommonJS compatibility

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ea9571a978833292fb2e27069c1dbb