### PR TITLE
Add configurable agents for implementation and review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Stepcat is a step-by-step agent orchestration solution that automates multi-step development plans using Claude Code (for implementation) and Codex (for code review). It uses a SQLite database to track execution state, iterations, and issues. For each step, it implements code via Claude Code, waits for GitHub Actions to pass, uses Codex to review the code with structured JSON output, and iterates until the step is complete.
+Stepcat is a step-by-step agent orchestration solution that automates multi-step development plans using Claude Code and Codex. Each stage can be configured to use either agent (Claude Code by default for implementation, Codex by default for review). It uses a SQLite database to track execution state, iterations, and issues. For each step, it implements code via the selected implementation agent, waits for GitHub Actions to pass, uses the configured review agent to analyze the changes with structured JSON output, and iterates until the step is complete.
 
-**Key Principle**: One commit per iteration (not per step) for complete audit trail. Each Claude Code execution creates a separate git commit, providing full transparency and traceability throughout the development process.
+**Key Principle**: One commit per iteration (not per step) for complete audit trail. Each implementation agent execution creates a separate git commit, providing full transparency and traceability throughout the development process.
 
 ## Common Commands
 

--- a/backend/__tests__/orchestrator.test.ts
+++ b/backend/__tests__/orchestrator.test.ts
@@ -75,7 +75,7 @@ Implement the feature
       mockClaudeRunner.run = jest.fn().mockResolvedValue({ success: true, commitSha: 'abc123' });
       mockGitHubChecker.waitForChecksToPass = jest.fn().mockResolvedValue(true);
       mockGitHubChecker.getLatestCommitSha = jest.fn().mockReturnValue('abc123');
-      mockCodexRunner.run = jest.fn().mockResolvedValue({ output: 'OK' });
+      mockCodexRunner.run = jest.fn().mockResolvedValue({ success: true, output: 'OK' });
       mockCodexRunner.parseCodexOutput = jest.fn().mockReturnValue({ result: 'PASS', issues: [] });
 
       const eventEmitter = new OrchestratorEventEmitter();
@@ -117,7 +117,7 @@ Implement the feature
       mockClaudeRunner.run = jest.fn().mockResolvedValue({ success: true, commitSha: 'def456' });
       mockGitHubChecker.waitForChecksToPass = jest.fn().mockResolvedValue(true);
       mockGitHubChecker.getLatestCommitSha = jest.fn().mockReturnValue('def456');
-      mockCodexRunner.run = jest.fn().mockResolvedValue({ output: 'OK' });
+      mockCodexRunner.run = jest.fn().mockResolvedValue({ success: true, output: 'OK' });
       mockCodexRunner.parseCodexOutput = jest.fn().mockReturnValue({ result: 'PASS', issues: [] });
 
       const orchestrator = new Orchestrator({
@@ -169,7 +169,7 @@ Implement the feature
         .mockResolvedValueOnce(true)
         .mockResolvedValue(true);
 
-      mockCodexRunner.run = jest.fn().mockResolvedValue({ output: 'OK' });
+      mockCodexRunner.run = jest.fn().mockResolvedValue({ success: true, output: 'OK' });
       mockCodexRunner.parseCodexOutput = jest.fn().mockReturnValue({ result: 'PASS', issues: [] });
 
       const orchestrator = new Orchestrator({
@@ -217,9 +217,9 @@ Implement the feature
 
       mockCodexRunner.run = jest
         .fn()
-        .mockResolvedValueOnce({ output: 'FAIL' })
-        .mockResolvedValueOnce({ output: 'PASS' })
-        .mockResolvedValue({ output: 'PASS' });
+        .mockResolvedValueOnce({ success: true, output: 'FAIL' })
+        .mockResolvedValueOnce({ success: true, output: 'PASS' })
+        .mockResolvedValue({ success: true, output: 'PASS' });
 
       mockCodexRunner.parseCodexOutput = jest
         .fn()
@@ -263,7 +263,7 @@ Implement the feature
       mockGitHubChecker.getLatestCommitSha = jest.fn().mockReturnValue('abc123');
       mockGitHubChecker.waitForChecksToPass = jest.fn().mockResolvedValue(true);
 
-      mockCodexRunner.run = jest.fn().mockResolvedValue({ output: 'FAIL' });
+      mockCodexRunner.run = jest.fn().mockResolvedValue({ success: true, output: 'FAIL' });
       mockCodexRunner.parseCodexOutput = jest.fn().mockReturnValue({
         result: 'FAIL',
         issues: [{ file: 'test.ts', severity: 'error', description: 'Always fails' }],
@@ -290,7 +290,7 @@ Implement the feature
       mockClaudeRunner.run = jest.fn().mockResolvedValue({ success: true, commitSha: 'abc123' });
       mockGitHubChecker.waitForChecksToPass = jest.fn().mockResolvedValue(true);
       mockGitHubChecker.getLatestCommitSha = jest.fn().mockReturnValue('abc123');
-      mockCodexRunner.run = jest.fn().mockResolvedValue({ output: 'OK' });
+      mockCodexRunner.run = jest.fn().mockResolvedValue({ success: true, output: 'OK' });
       mockCodexRunner.parseCodexOutput = jest.fn().mockReturnValue({ result: 'PASS', issues: [] });
 
       const eventEmitter = new OrchestratorEventEmitter();
@@ -318,7 +318,7 @@ Implement the feature
       mockClaudeRunner.run = jest.fn().mockResolvedValue({ success: true, commitSha: 'abc123' });
       mockGitHubChecker.waitForChecksToPass = jest.fn().mockResolvedValue(true);
       mockGitHubChecker.getLatestCommitSha = jest.fn().mockReturnValue('abc123');
-      mockCodexRunner.run = jest.fn().mockResolvedValue({ output: 'OK' });
+      mockCodexRunner.run = jest.fn().mockResolvedValue({ success: true, output: 'OK' });
       mockCodexRunner.parseCodexOutput = jest.fn().mockReturnValue({ result: 'PASS', issues: [] });
 
       const eventEmitter = new OrchestratorEventEmitter();
@@ -348,7 +348,7 @@ Implement the feature
       mockClaudeRunner.run = jest.fn().mockResolvedValue({ success: true, commitSha: 'abc123' });
       mockGitHubChecker.waitForChecksToPass = jest.fn().mockResolvedValue(true);
       mockGitHubChecker.getLatestCommitSha = jest.fn().mockReturnValue('abc123');
-      mockCodexRunner.run = jest.fn().mockResolvedValue({ output: 'FAIL' });
+      mockCodexRunner.run = jest.fn().mockResolvedValue({ success: true, output: 'FAIL' });
       mockCodexRunner.parseCodexOutput = jest.fn().mockReturnValue({
         result: 'FAIL',
         issues: [{ file: 'test.ts', severity: 'error', description: 'Fails' }],
@@ -367,7 +367,7 @@ Implement the feature
       mockClaudeRunner.run = jest.fn().mockResolvedValue({ success: true, commitSha: 'abc123' });
       mockGitHubChecker.waitForChecksToPass = jest.fn().mockResolvedValue(true);
       mockGitHubChecker.getLatestCommitSha = jest.fn().mockReturnValue('abc123');
-      mockCodexRunner.run = jest.fn().mockResolvedValue({ output: 'FAIL' });
+      mockCodexRunner.run = jest.fn().mockResolvedValue({ success: true, output: 'FAIL' });
       mockCodexRunner.parseCodexOutput = jest.fn().mockReturnValue({
         result: 'FAIL',
         issues: [{ file: 'test.ts', severity: 'error', description: 'Fails' }],
@@ -381,6 +381,70 @@ Implement the feature
       });
 
       await expect(orchestrator.run()).rejects.toThrow(/exceeded maximum iterations \(5\)/);
+    });
+  });
+
+  describe('agent configuration', () => {
+    it('allows using Codex for implementation iterations', async () => {
+      mockCodexRunner.run = jest.fn().mockImplementation(async (options: any) => {
+        if (options.expectCommit) {
+          return { success: true, output: 'Implementation complete', commitSha: 'abc123' };
+        }
+        return {
+          success: true,
+          output: JSON.stringify({ result: 'PASS', issues: [] }),
+        };
+      });
+      mockCodexRunner.parseCodexOutput = jest.fn().mockReturnValue({ result: 'PASS', issues: [] });
+
+      mockClaudeRunner.run = jest.fn();
+      mockGitHubChecker.waitForChecksToPass = jest.fn().mockResolvedValue(true);
+      mockGitHubChecker.getLatestCommitSha = jest.fn().mockReturnValue('abc123');
+
+      const orchestrator = new Orchestrator({
+        planFile,
+        workDir: tempDir,
+        githubToken: 'test-token',
+        implementationAgent: 'codex',
+      });
+
+      await orchestrator.run();
+
+      expect(mockCodexRunner.run).toHaveBeenCalled();
+      expect(mockCodexRunner.run.mock.calls[0][0].expectCommit).toBe(true);
+      expect(mockClaudeRunner.run).not.toHaveBeenCalled();
+    });
+
+    it('allows using Claude Code for code review', async () => {
+      mockClaudeRunner.run = jest.fn().mockImplementation(async (options: any) => {
+        if (options.captureOutput) {
+          return {
+            success: true,
+            commitSha: null,
+            output: JSON.stringify({ result: 'PASS', issues: [] }),
+          };
+        }
+        return { success: true, commitSha: 'abc123' };
+      });
+
+      mockCodexRunner.run = jest.fn();
+      mockCodexRunner.parseCodexOutput = jest.fn().mockReturnValue({ result: 'PASS', issues: [] });
+
+      mockGitHubChecker.waitForChecksToPass = jest.fn().mockResolvedValue(true);
+      mockGitHubChecker.getLatestCommitSha = jest.fn().mockReturnValue('abc123');
+
+      const orchestrator = new Orchestrator({
+        planFile,
+        workDir: tempDir,
+        githubToken: 'test-token',
+        reviewAgent: 'claude',
+      });
+
+      await orchestrator.run();
+
+      expect(mockClaudeRunner.run).toHaveBeenCalled();
+      expect(mockCodexRunner.run).not.toHaveBeenCalled();
+      expect(mockCodexRunner.parseCodexOutput).toHaveBeenCalled();
     });
   });
 });

--- a/backend/events.ts
+++ b/backend/events.ts
@@ -131,6 +131,7 @@ export interface CodexReviewStartEvent extends StepCatEvent {
   type: 'codex_review_start';
   iterationId: number;
   promptType: 'implementation' | 'build_fix' | 'review_fix';
+  agent?: 'claude' | 'codex';
 }
 
 export interface CodexReviewCompleteEvent extends StepCatEvent {
@@ -138,6 +139,7 @@ export interface CodexReviewCompleteEvent extends StepCatEvent {
   iterationId: number;
   result: 'PASS' | 'FAIL';
   issueCount: number;
+  agent?: 'claude' | 'codex';
 }
 
 export interface StateSyncEvent extends StepCatEvent {

--- a/docs/plans/DB.md
+++ b/docs/plans/DB.md
@@ -91,8 +91,8 @@ Add new event types to the union:
 - `iteration_complete`: { type, timestamp, stepId, iterationNumber, commitSha, status }
 - `issue_found`: { type, timestamp, iterationId, issueType, description, filePath?, lineNumber?, severity? }
 - `issue_resolved`: { type, timestamp, issueId }
-- `codex_review_start`: { type, timestamp, iterationId, promptType }
-- `codex_review_complete`: { type, timestamp, iterationId, result, issueCount }
+- `codex_review_start`: { type, timestamp, iterationId, promptType, agent? }
+- `codex_review_complete`: { type, timestamp, iterationId, result, issueCount, agent? }
 
 Update existing events to include iteration context where relevant:
 - `build_attempt`: Add `iterationId` field

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -115,6 +115,7 @@ export interface CodexReviewStartEvent extends BaseEvent {
   type: 'codex_review_start';
   iterationId?: number;
   promptType: string;
+  agent?: 'claude' | 'codex';
 }
 
 export interface CodexReviewCompleteEvent extends BaseEvent {
@@ -122,6 +123,7 @@ export interface CodexReviewCompleteEvent extends BaseEvent {
   iterationId?: number;
   result: 'PASS' | 'FAIL';
   issueCount: number;
+  agent?: 'claude' | 'codex';
 }
 
 export interface LogEvent extends BaseEvent {


### PR DESCRIPTION
## Summary
- allow configuring the implementation and review agents (Claude or Codex) in the orchestrator and CLI
- update the Claude and Codex runners and events to support the new agent selection flow
- refresh documentation and tests to cover the configurable agents and new event data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68eaa76329f48332b41ab026d9c10e1f