### PR TITLE
refresh plan on resume

### DIFF
--- a/backend/__tests__/orchestrator.vitest.ts
+++ b/backend/__tests__/orchestrator.vitest.ts
@@ -226,7 +226,7 @@ More changes
       const db2 = new Database(tempDir);
       const steps = db2.getSteps(plan.id);
       expect(steps).toHaveLength(4);
-      expect(steps[1].title).toBe('Implementation');
+      expect(steps[1].title).toBe('Implementation Updated');
       expect(steps[2].title).toBe('New Future');
       expect(steps[3].title).toBe('Extra Step');
       db2.close();

--- a/backend/database.ts
+++ b/backend/database.ts
@@ -114,6 +114,12 @@ export class Database implements Storage {
     stmt.run(status, updatedAt, stepId);
   }
 
+  updateStepTitle(stepId: number, title: string): void {
+    const updatedAt = new Date().toISOString();
+    const stmt = this.db.prepare('UPDATE steps SET title = ?, updatedAt = ? WHERE id = ?');
+    stmt.run(title, updatedAt, stepId);
+  }
+
   replacePendingStepsFromPlan(
     planId: number,
     startStepNumber: number,

--- a/backend/orchestrator.ts
+++ b/backend/orchestrator.ts
@@ -1034,8 +1034,17 @@ CRITICAL REQUIREMENTS:
       return;
     }
 
-    const startStepNumber = currentStep.stepNumber + 1;
     const parsedSteps = this.parser.parseSteps();
+    const currentPlanStep = parsedSteps.find((step) => step.number === currentStep.stepNumber);
+    if (currentStep.status === 'pending' && currentPlanStep && currentPlanStep.title !== currentStep.title) {
+      this.storage.updateStepTitle(currentStep.id, currentPlanStep.title);
+      this.log(
+        `Updated pending step ${currentStep.stepNumber} title from plan`,
+        "info"
+      );
+    }
+
+    const startStepNumber = currentStep.stepNumber + 1;
     const futureSteps = parsedSteps.filter((step) => step.number >= startStepNumber);
 
     const { deletedCount, createdCount } = this.storage.replacePendingStepsFromPlan(

--- a/backend/storage.ts
+++ b/backend/storage.ts
@@ -22,6 +22,7 @@ export interface Storage {
   createStep(planId: number, stepNumber: number, title: string): DbStep;
   getSteps(planId: number): DbStep[];
   updateStepStatus(stepId: number, status: DbStep['status']): void;
+  updateStepTitle(stepId: number, title: string): void;
   replacePendingStepsFromPlan(
     planId: number,
     startStepNumber: number,


### PR DESCRIPTION
Solution:
- Reload the stored plan file on resume so updated content and prompts are current.
- Replace pending steps after the current step with the latest plan steps using a guarded transaction.
- Add an orchestrator resume test that verifies updated plan steps are refreshed.