### PR TITLE
Keep TUI open after run by default; add `--exit-on-complete` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ stepcat --file plan.md --dir /path/to/project
 - `-t, --token <token>` - GitHub token (optional, defaults to `GITHUB_TOKEN` env var)
 - `--build-timeout <minutes>` - GitHub Actions check timeout in minutes (default: 30)
 - `--agent-timeout <minutes>` - Agent execution timeout in minutes (default: 30)
-- `--keep-open` - Keep the TUI open after execution completes
+- `--exit-on-complete` - Exit the TUI after execution completes (default: stay open)
 - `--implementation-agent <agent>` - Agent to use for implementation iterations (`claude` or `codex`, default: `claude`)
 - `--review-agent <agent>` - Agent to use for code review (`claude` or `codex`, default: `codex`)
 

--- a/backend/cli.ts
+++ b/backend/cli.ts
@@ -22,7 +22,7 @@ interface CliOptions {
   buildTimeout?: number;
   agentTimeout?: number;
   maxIterations?: number;
-  keepOpen?: boolean;
+  exitOnComplete?: boolean;
   implementationAgent?: string;
   reviewAgent?: string;
   preflight?: boolean;
@@ -45,7 +45,7 @@ program
   .option('--build-timeout <minutes>', 'GitHub Actions check timeout in minutes (default: 30)', parseInt)
   .option('--agent-timeout <minutes>', 'Agent execution timeout in minutes (default: 30)', parseInt)
   .option('--max-iterations <count>', 'Maximum iterations per step (default: 3)', parseInt)
-  .option('--keep-open', 'Keep the TUI open after execution completes')
+  .option('--exit-on-complete', 'Exit the TUI after execution completes (default: stay open)')
   .option('--implementation-agent <agent>', 'Agent to use for implementation (claude|codex)')
   .option('--review-agent <agent>', 'Agent to use for code review (claude|codex)')
   .option('--preflight', 'Run preflight check to detect missing permissions')
@@ -271,7 +271,7 @@ program
         process.exit(0);
       }
 
-      if (options.keepOpen) {
+      if (!options.exitOnComplete) {
         await new Promise(() => {});
       }
 


### PR DESCRIPTION
### Motivation

- Prevent the CLI from exiting immediately when a run finishes so the TUI remains open for inspection by default; provide an explicit flag to opt into automatic exit.

### Description

- Replaced the previous `--keep-open` behavior with a new `--exit-on-complete` flag and inverted the control so the TUI stays open by default unless `--exit-on-complete` is passed.
- Updated the `CliOptions` type and the CLI option registration in `backend/cli.ts` and adjusted the completion logic to await indefinitely unless `--exit-on-complete` is true.
- Updated the CLI documentation in `README.md` to document the new `--exit-on-complete` option.

### Testing

- Ran `npm run lint` (ESLint) which completed without errors.
- Ran the full test suite with `npm test` (Jest + Vitest) and all automated tests passed (`Tests: 75 passed, 75 total` for Jest and Vitest suites passed as shown by the test run output).
- Ran `npm run build` which completed successfully; `just`-based commands were not available in this environment and therefore reported as not found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697baaf2a60483328f90278ef7e04002)