### PR TITLE
Support .envrc.local for local secrets

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,3 @@
 use flake
 dotenv
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ frontend/dist/
 frontend/node_modules/
 *.log
 .env
+.envrc.local
 .DS_Store
 .direnv/


### PR DESCRIPTION
## Summary
- Add `source_env_if_exists .envrc.local` to `.envrc` so secrets can be loaded from 1Password
- Add `.envrc.local` to `.gitignore`

## Test plan
- [ ] `direnv allow` picks up `.envrc.local` with `op` calls
- [ ] Existing `.env`-based workflow still works