### PR TITLE
chore: add script/setup for worktree environment setup

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# script/setup: Set up the project after an initial clone or in a new worktree.
+#               Symlinks .env and .envrc.local from the main repository when
+#               running inside a git worktree, then allows direnv.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+git_dir="$(git rev-parse --git-dir)"
+git_common_dir="$(git rev-parse --git-common-dir)"
+
+if [ "$(cd "$git_dir" && pwd -P)" != "$(cd "$git_common_dir" && pwd -P)" ]; then
+  main_repo="$(cd "$git_common_dir/.." && pwd -P)"
+  worktree_root="$(pwd -P)"
+
+  echo "==> Detected worktree, symlinking env files from $main_repo..."
+
+  for file in .env .envrc.local; do
+    source_file="$main_repo/$file"
+    target_file="$worktree_root/$file"
+
+    if [ -L "$target_file" ]; then
+      echo "  $file is already symlinked."
+    elif [ -e "$target_file" ]; then
+      echo "  $file already exists (not a symlink), skipping."
+    elif [ -e "$source_file" ]; then
+      ln -s "$source_file" "$target_file"
+      echo "  Symlinked $file -> $source_file"
+    else
+      echo "  $file not found in main repo, skipping."
+    fi
+  done
+else
+  echo "==> Not in a worktree, skipping env file symlinks."
+fi
+
+if command -v direnv &>/dev/null; then
+  echo "==> Allowing direnv..."
+  direnv allow .
+else
+  echo "==> direnv not found, skipping direnv allow."
+fi
+
+echo "==> Done."


### PR DESCRIPTION
## Summary

Adds `script/setup` following the [scripts-to-rule-them-all](https://github.com/github/scripts-to-rule-them-all) convention. When run inside a git worktree, it symlinks `.env` and `.envrc.local` from the main repository so that environment variables and secrets are available without manual copying. It also runs `direnv allow` to activate the environment immediately.

When run in the main repo (not a worktree), symlink creation is skipped and only `direnv allow` is executed.

## How it works

- Compares `git rev-parse --git-dir` with `--git-common-dir` to detect worktrees
- Derives the main repo root from the common git directory
- Symlinks `.env` and `.envrc.local` with guards for already-existing files
- Runs `direnv allow` if direnv is installed
